### PR TITLE
fix: 롯데시네마 영화 상영 정보 러닝타임 계산 로직 수정

### DIFF
--- a/src/main/java/com/cinefinder/global/filter/JwtFilter.java
+++ b/src/main/java/com/cinefinder/global/filter/JwtFilter.java
@@ -151,7 +151,8 @@ public class JwtFilter extends OncePerRequestFilter {
 		String path = request.getServletPath();
 		return path.equals("/api/login") || path.equals("/api/signup/session")
 			|| path.equals("/api/logout") || path.equals("/api/signup/nickname")
-			|| path.startsWith("/api/movie") || path.startsWith("/api/theater");
+			|| path.startsWith("/api/movie") || path.startsWith("/api/theater")
+				|| path.startsWith("/api/screen");
 	}
 }
 

--- a/src/main/java/com/cinefinder/screen/data/dto/ScreenScheduleResponseDto.java
+++ b/src/main/java/com/cinefinder/screen/data/dto/ScreenScheduleResponseDto.java
@@ -18,9 +18,9 @@ public class ScreenScheduleResponseDto {
     private String screenCd;
     private String screenNm;
     private String playYmd;
-    private String playStartTm;
-    private String playEndTm;
+    private String playStartTime;
+    private String playEndTime;
     private String runningTime;
     private String seatRemainCnt;
-    private String seatCapacity;
+    private String seatCapacityCnt;
 }

--- a/src/main/java/com/cinefinder/screen/service/CgvScreenScheduleServiceImpl.java
+++ b/src/main/java/com/cinefinder/screen/service/CgvScreenScheduleServiceImpl.java
@@ -135,6 +135,8 @@ public class CgvScreenScheduleServiceImpl implements ScreenScheduleService {
                     item.path("MovieCd").asText(),
                     item.path("MovieNmKor").asText(),
                     item.path("MovieNmEng").asText(),
+                    item.path("PlatformCd").asText(),
+                    item.path("PlatformNm").asText(),
                     item.path("ScreenCd").asText(),
                     item.path("ScreenNm").asText(),
                     item.path("PlayYmd").asText(),
@@ -142,9 +144,7 @@ public class CgvScreenScheduleServiceImpl implements ScreenScheduleService {
                     endTime.substring(0, 2) + ":" + endTime.substring(2),
                     item.path("RunningTime").asText(),
                     item.path("SeatRemainCnt").asText(),
-                    item.path("SeatCapacity").asText(),
-                    item.path("PlatformCd").asText(),
-                    item.path("PlatformNm").asText()
+                    item.path("SeatCapacity").asText()
             );
             result.add(dto);
         }

--- a/src/main/java/com/cinefinder/screen/service/LotteScreenScheduleServiceImpl.java
+++ b/src/main/java/com/cinefinder/screen/service/LotteScreenScheduleServiceImpl.java
@@ -105,8 +105,19 @@ public class LotteScreenScheduleServiceImpl implements ScreenScheduleService {
 
             if (null !=start && null != end && !start.isEmpty() && !end.isEmpty()) {
                 try {
-                    LocalTime startTime = LocalTime.parse(start);
-                    LocalTime endTime = LocalTime.parse(end);
+                    int startHour = Integer.parseInt(start.substring(0, 2));
+                    int endHour = Integer.parseInt(end.substring(0, 2));
+
+                    String startStr = start;
+                    String endStr = end;
+
+                    if (12 < startHour) {
+                        startStr = String.format("%02d", startHour-12) + start.substring(2);
+                        endStr = String.format("%02d", endHour-12) + end.substring(2);
+                    }
+
+                    LocalTime startTime = LocalTime.parse(startStr);
+                    LocalTime endTime = LocalTime.parse(endStr);
 
                     if (endTime.isBefore(startTime)) {
                         endTime = endTime.plusHours(24);
@@ -124,6 +135,8 @@ public class LotteScreenScheduleServiceImpl implements ScreenScheduleService {
                     item.path("RepresentationMovieCode").asText(),
                     item.path("MovieNameKR").asText(),
                     item.path("MovieNameUS").asText(),
+                    item.path("FilmCode").asText(),
+                    item.path("FilmNameKR").asText(),
                     item.path("ScreenID").asText(),
                     item.path("ScreenNameKR").asText(""),
                     item.path("StartTime").asText(),
@@ -131,9 +144,7 @@ public class LotteScreenScheduleServiceImpl implements ScreenScheduleService {
                     item.path("EndTime").asText(),
                     String.valueOf(runtimeMinutes),
                     item.path("BookingSeatCount").asText(),
-                    item.path("TotalSeatCount").asText(),
-                    item.path("FilmCode").asText(),
-                    item.path("FilmNameKR").asText()
+                    item.path("TotalSeatCount").asText()
             );
 
             result.add(dto);

--- a/src/main/java/com/cinefinder/screen/service/MegaScreenScheduleServiceImpl.java
+++ b/src/main/java/com/cinefinder/screen/service/MegaScreenScheduleServiceImpl.java
@@ -84,6 +84,8 @@ public class MegaScreenScheduleServiceImpl implements ScreenScheduleService{
                     item.path("rpstMovieNo").asText(),
                     item.path("movieNm").asText(),
                     item.path("movieEngNm").asText(),
+                    item.path("theabKindCd").asText(),
+                    item.path("playKindNm").asText(),
                     item.path("theabNo").asText(),
                     item.path("theabExpoNm").asText(),
                     item.path("playDe").asText(),
@@ -91,9 +93,7 @@ public class MegaScreenScheduleServiceImpl implements ScreenScheduleService{
                     item.path("playEndTime").asText(),
                     item.path("moviePlayTime").asText(),
                     item.path("restSeatCnt").asText(),
-                    item.path("totSeatCnt").asText(),
-                    item.path("theabKindCd").asText(),
-                    item.path("playKindNm").asText()
+                    item.path("totSeatCnt").asText()
             );
             result.add(dto);
         }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 롯데시네마의 상영 러닝타임 계산 중 종료시간이 24시가 넘는 상황의 오류 해결
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 롯데시네마 상영 러닝타임 계산 로직 수정
  - 영화 상영 정보 응답 DTO 생성 과정에서 순서 오류 수정
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #19 
