### PR TITLE
fix: 영화 정보 수집 및 저장 로직 에러

### DIFF
--- a/src/main/java/com/cinefinder/global/util/statuscode/ApiStatus.java
+++ b/src/main/java/com/cinefinder/global/util/statuscode/ApiStatus.java
@@ -23,6 +23,7 @@ public enum ApiStatus {
 	_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 405, "허용되지 않은 메소드입니다."),
 	_CONFLICT(HttpStatus.CONFLICT, 409, "충돌이 발생했습니다."),
 	_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류가 발생했습니다."),
+	_INVALID_URI_FORMAT(HttpStatus.INTERNAL_SERVER_ERROR, 500, "유효하지 않은 URI 형식입니다."),
 	_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 503, "서비스를 사용할 수 없습니다."),
 	_EMBEDDING_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "임베딩 서버 호출에 실패했습니다."),
 	_READ_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "DB 읽기에 실패하였습니다."),

--- a/src/main/java/com/cinefinder/movie/controller/MovieController.java
+++ b/src/main/java/com/cinefinder/movie/controller/MovieController.java
@@ -20,17 +20,17 @@ public class MovieController {
     private final BoxOfficeService boxOfficeService;
     private final MovieDetailService movieDetailService;
 
-    @GetMapping("/daily-box-office")
+    @GetMapping("/box-office/daily")
     public ResponseEntity<BaseResponse<List<BoxOffice>>> fetchDailyBoxOfficeInfo() {
         return ResponseMapper.successOf(ApiStatus._OK, boxOfficeService.getDailyBoxOfficeInfo(), MovieController.class);
     }
 
-    @GetMapping("/movie-details")
+    @GetMapping("/details")
     public ResponseEntity<BaseResponse<MovieDetails>> fetchMovieDetails(@RequestParam String title) {
         return ResponseMapper.successOf(ApiStatus._OK, movieDetailService.getMovieDetails(title), MovieController.class);
     }
 
-    @PostMapping("/multiplexMovieDetails")
+    @PostMapping("/details/multiplex")
     public ResponseEntity<BaseResponse<Void>> fetchMultiplexMovieDetails() {
         movieDetailService.fetchMultiplexMovieDetails();
         return ResponseMapper.successOf(ApiStatus._OK, null, MovieController.class);

--- a/src/main/java/com/cinefinder/movie/controller/MovieController.java
+++ b/src/main/java/com/cinefinder/movie/controller/MovieController.java
@@ -30,9 +30,9 @@ public class MovieController {
         return ResponseMapper.successOf(ApiStatus._OK, movieDetailService.getMovieDetails(title), MovieController.class);
     }
 
-    @PostMapping("/multiflexMovieDetails")
-    public ResponseEntity<BaseResponse<Void>> fetchMultiflexMovieDetails() {
-        movieDetailService.fetchMultiflexMovieDetails();
+    @PostMapping("/multiplexMovieDetails")
+    public ResponseEntity<BaseResponse<Void>> fetchMultiplexMovieDetails() {
+        movieDetailService.fetchMultiplexMovieDetails();
         return ResponseMapper.successOf(ApiStatus._OK, null, MovieController.class);
     }
 }

--- a/src/main/java/com/cinefinder/movie/scheduler/MovieScheduler.java
+++ b/src/main/java/com/cinefinder/movie/scheduler/MovieScheduler.java
@@ -3,10 +3,12 @@ package com.cinefinder.movie.scheduler;
 import com.cinefinder.movie.service.BoxOfficeService;
 import com.cinefinder.movie.service.MovieDetailService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class MovieScheduler {
     private final BoxOfficeService boxOfficeService;
@@ -17,15 +19,13 @@ public class MovieScheduler {
         try {
             boxOfficeService.fetchDailyBoxOfficeInfo();
         } catch (Exception e) {
-            // TODO: 박스오피스 정보 스케줄러 실패 시 예외 처리
-            throw new RuntimeException("박스오피스 정보 패치 중 오류 발생", e);
+            log.error("‼️ 박스오피스 정보 패치 중 오류 발생", e);
         }
 
         try {
-            movieDetailService.fetchMultiflexMovieDetails();
+            movieDetailService.fetchMultiplexMovieDetails();
         } catch (Exception e) {
-            // TODO: 멀티플렉스 3사 영화 상세정보 스케줄러 실패 시 예외 처리
-            throw new RuntimeException("멀티플렉스 3사 영화 상세정보 패치 중 오류 발생", e);
+            log.error("‼️ 멀티플렉스 3사 영화 상세정보 패치 중 오류 발생", e);
         }
     }
 }

--- a/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
@@ -1,5 +1,7 @@
 package com.cinefinder.movie.service;
 
+import com.cinefinder.global.exception.custom.CustomException;
+import com.cinefinder.global.util.statuscode.ApiStatus;
 import com.cinefinder.movie.data.model.BoxOffice;
 import com.cinefinder.movie.util.UtilString;
 import com.cinefinder.movie.util.UtilParse;
@@ -9,15 +11,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BoxOfficeService {
     @Value("${api.kobis.request-url}")
@@ -93,9 +99,12 @@ public class BoxOfficeService {
             log.info("⭕ REDIS 저장 완료");
 
             return dailyBoxOfficeList;
+        } catch (URISyntaxException e) {
+            throw new CustomException(ApiStatus._INVALID_URI_FORMAT, "일간 박스오피스 정보 저장 중 URI 구분 분석 오류 발생");
+        } catch (RestClientException e) {
+            throw new CustomException(ApiStatus._EXTERNAL_API_FAIL, "일간 박스오피스 정보 저장 중 외부 API 호출 오류 발생");
         } catch (Exception e) {
-            // TODO: 예외 유형별로 분기 처리 (URI 생성 오류, 문자열 변환 실패 등)
-            throw new RuntimeException("일간 박스오피스 정보 저장 중 오류 발생", e);
+            throw new CustomException(ApiStatus._OPERATION_FAIL, "일간 박스오피스 정보 저장 중 알 수 없는 오류 발생");
         }
     }
 }

--- a/src/main/java/com/cinefinder/movie/service/MovieHelperService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieHelperService.java
@@ -1,5 +1,7 @@
 package com.cinefinder.movie.service;
 
+import com.cinefinder.global.exception.custom.CustomException;
+import com.cinefinder.global.util.statuscode.ApiStatus;
 import com.cinefinder.movie.data.model.MovieDetails;
 import com.cinefinder.movie.util.UtilParse;
 import com.cinefinder.movie.util.UtilString;
@@ -12,8 +14,10 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,112 +40,126 @@ public class MovieHelperService {
     private final RestTemplate restTemplate = new RestTemplate();
 
     public List<MovieDetails> requestMovieCgvApi() {
-        List<MovieDetails> cgvMovieDetailsList;
-        List<MovieDetails> cgvResult = new ArrayList<>();
-        MultiValueMap<String, Object> cgvMap = new LinkedMultiValueMap<>();
-        int i = 1;
+        try {
+            String cgvResponse = restTemplate.getForObject(cgvRequestUrl, String.class);
 
-        do {
-            cgvMap.set("iPage", String.valueOf(i++));
-            cgvMap.set("pageRow", "20");
-            cgvMap.set("mtype", "now");
-            cgvMap.set("morder", "TicketRate");
-            cgvMap.set("mnowflag", "1");
-            cgvMap.set("mdistype", "");
-            cgvMap.set("flag", "MLIST");
-
-            HttpHeaders cgvHeaders = new HttpHeaders();
-            cgvHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
-            HttpEntity<MultiValueMap<String, Object>> cgvRequest = new HttpEntity<>(cgvMap, cgvHeaders);
-
-            String cgvResponse = restTemplate.postForObject(cgvRequestUrl, cgvRequest, String.class);
-
-            cgvMovieDetailsList = UtilParse.extractCgvMovieList(cgvResponse);
-            cgvResult.addAll(cgvMovieDetailsList);
-        } while (!cgvMovieDetailsList.isEmpty());
-
-        return cgvResult;
+            return UtilParse.extractCgvMovieList(cgvResponse);
+        } catch (RestClientException e) {
+            throw new CustomException(ApiStatus._EXTERNAL_API_FAIL, "CGV 영화목록 API 호출 실패");
+        } catch (Exception e) {
+            throw new CustomException(ApiStatus._INTERNAL_SERVER_ERROR, "CGV 영화목록 API 호출 중 알 수 없는 오류 발생");
+        }
     }
 
     public List<MovieDetails> requestMovieMegaBoxApi() {
-        String jsonBody = "{"
-            + "\"currentPage\":\"1\","
-            + "\"recordCountPerPage\":\"100\","
-            + "\"pageType\":\"ticketing\","
-            + "\"ibxMovieNmSearch\":\"\","
-            + "\"onairYn\":\"Y\","
-            + "\"specialType\":\"\","
-            + "\"specialYn\":\"N\""
-            + "}";
-        HttpHeaders megaBoxHeaders = new HttpHeaders();
-        megaBoxHeaders.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> megaBoxRequest = new HttpEntity<>(jsonBody, megaBoxHeaders);
+        try {
+            String jsonBody = "{"
+                + "\"currentPage\":\"1\","
+                + "\"recordCountPerPage\":\"150\","
+                + "\"pageType\":\"ticketing\","
+                + "\"ibxMovieNmSearch\":\"\","
+                + "\"onairYn\":\"Y\","
+                + "\"specialType\":\"\","
+                + "\"specialYn\":\"N\""
+                + "}";
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> request = new HttpEntity<>(jsonBody, headers);
 
-        String megaBoxResponse = restTemplate.postForObject(megaBoxRequestUrl, megaBoxRequest, String.class);
+            String response = restTemplate.postForObject(megaBoxRequestUrl, request, String.class);
 
-        return UtilParse.extractMegaBoxMovieList(megaBoxResponse);
+            return UtilParse.extractMegaBoxMovieList(response);
+        } catch (IOException e) {
+            throw new CustomException(ApiStatus._EXTERNAL_API_FAIL, "메가박스 영화목록 API 호출 실패");
+        } catch (Exception e) {
+            throw new CustomException(ApiStatus._INTERNAL_SERVER_ERROR, "메가박스 영화목록 API 호출 중 알 수 없는 오류 발생");
+        }
     }
 
     public List<MovieDetails> requestMovieLotteCinemaApi() {
-        MultiValueMap<String, Object> lotteCinemaMap = new LinkedMultiValueMap<>();
-        String paramList = "{\n"
-            + "  \"MethodName\": \"GetMoviesToBe\",\n"
-            + "  \"channelType\": \"HO\",\n"
-            + "  \"osType\": \"Chrome\",\n"
-            + "  \"osVersion\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36\",\n"
-            + "  \"multiLanguageID\": \"KR\",\n"
-            + "  \"division\": 1,\n"
-            + "  \"moviePlayYN\": \"Y\",\n"
-            + "  \"orderType\": \"1\",\n"
-            + "  \"blockSize\": 100,\n"
-            + "  \"pageNo\": 1,\n"
-            + "  \"memberOnNo\": \"\",\n"
-            + "  \"imgdivcd\": 2\n"
-            + "}";
-        lotteCinemaMap.add("paramList", paramList);
+        try {
+            List<MovieDetails> movieDetailsList = new ArrayList<>();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpHeaders lotteCinemaHeaders = new HttpHeaders();
-        lotteCinemaHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        HttpEntity<MultiValueMap<String, Object>> lotteCinemaRequest = new HttpEntity<>(lotteCinemaMap, lotteCinemaHeaders);
+            String paramList = """
+                {
+                  "MethodName": "GetMoviesToBe",
+                  "channelType": "HO",
+                  "osType": "Chrome",
+                  "osVersion": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+                  "multiLanguageID": "KR",
+                  "division": 1,
+                  "moviePlayYN": "%s",
+                  "orderType": "%s",
+                  "blockSize": 100,
+                  "pageNo": 1,
+                  "memberOnNo": "",
+                  "imgdivcd": 2
+                }
+            """;
 
-        String lotteCinemaResponse = restTemplate.postForObject(lotteCinemaRequestUrl, lotteCinemaRequest, String.class);
+            String[][] requestParams = {
+                    {"N", "5"},
+                    {"Y", "1"}
+            };
 
-        return UtilParse.extractLotteCinemaMovieList(lotteCinemaResponse);
+            for (String[] params : requestParams) {
+                String formattedParam = String.format(paramList, params[0], params[1]);
+                MultiValueMap<String, Object> payload = new LinkedMultiValueMap<>();
+                payload.add("paramList", formattedParam);
+
+                HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(payload, headers);
+                String response = restTemplate.postForObject(lotteCinemaRequestUrl, request, String.class);
+
+                movieDetailsList.addAll(UtilParse.extractLotteCinemaMovieList(response));
+            }
+
+            return movieDetailsList;
+        } catch (IOException e) {
+            throw new CustomException(ApiStatus._EXTERNAL_API_FAIL, "롯데시네마 영화목록 API 호출 실패");
+        } catch (Exception e) {
+            throw new CustomException(ApiStatus._INTERNAL_SERVER_ERROR, "롯데시네마 영화목록 API 호출 중 알 수 없는 오류 발생");
+        }
     }
 
     public Map<String, MovieDetails> mergeAndDeduplicateMovieDetails(List<MovieDetails> totalMovieDetails) {
-        Map<String, MovieDetails> distinctMap = new HashMap<>();
-        for (MovieDetails movieDetails : totalMovieDetails) {
-            String normalizeMovieKey = UtilString.normalizeMovieKey(movieDetails.getTitle());
-            String title = movieDetails.getTitle();
-            String cgvCode = movieDetails.getCgvCode();
-            String megaBoxCode = movieDetails.getMegaBoxCode();
-            String lotteCinemaCode = movieDetails.getLotteCinemaCode();
-            MovieDetails originMovieDetails = distinctMap.get(normalizeMovieKey);
+        try {
+            Map<String, MovieDetails> distinctMap = new HashMap<>();
+            for (MovieDetails movieDetails : totalMovieDetails) {
+                String normalizeMovieKey = UtilString.normalizeMovieKey(movieDetails.getTitle());
+                String title = movieDetails.getTitle();
+                String cgvCode = movieDetails.getCgvCode();
+                String megaBoxCode = movieDetails.getMegaBoxCode();
+                String lotteCinemaCode = movieDetails.getLotteCinemaCode();
+                MovieDetails originMovieDetails = distinctMap.get(normalizeMovieKey);
 
-            if (IGNORE_TITLE_LIST.contains(title)) continue;
+                if (IGNORE_TITLE_LIST.contains(title)) continue;
 
-            if (originMovieDetails != null) {
-                if (!StringUtil.isNullOrEmpty(cgvCode)) {
-                    originMovieDetails.setCgvCode(movieDetails.getCgvCode());
+                if (originMovieDetails != null) {
+                    if (!StringUtil.isNullOrEmpty(cgvCode)) {
+                        originMovieDetails.setCgvCode(movieDetails.getCgvCode());
+                    }
+
+                    if (!StringUtil.isNullOrEmpty(megaBoxCode)) {
+                        originMovieDetails.setMegaBoxCode(movieDetails.getMegaBoxCode());
+                    }
+
+                    if (!StringUtil.isNullOrEmpty(lotteCinemaCode)) {
+                        originMovieDetails.setLotteCinemaCode(movieDetails.getLotteCinemaCode());
+                    }
+
+                    if (originMovieDetails.getTitle().length() >= title.length()) {
+                        movieDetails = originMovieDetails;
+                    }
                 }
 
-                if (!StringUtil.isNullOrEmpty(megaBoxCode)) {
-                    originMovieDetails.setMegaBoxCode(movieDetails.getMegaBoxCode());
-                }
-
-                if (!StringUtil.isNullOrEmpty(lotteCinemaCode)) {
-                    originMovieDetails.setLotteCinemaCode(movieDetails.getLotteCinemaCode());
-                }
-
-                if (originMovieDetails.getTitle().length() >= title.length()) {
-                    movieDetails = originMovieDetails;
-                }
+                distinctMap.putIfAbsent(normalizeMovieKey, movieDetails);
             }
 
-            distinctMap.putIfAbsent(normalizeMovieKey, movieDetails);
+            return distinctMap;
+        } catch (Exception e) {
+            throw new CustomException(ApiStatus._INTERNAL_SERVER_ERROR, "멀티플렉스 영화목록 병합 중 알 수 없는 오류 발생");
         }
-
-        return distinctMap;
     }
 }

--- a/src/main/java/com/cinefinder/movie/util/UtilParse.java
+++ b/src/main/java/com/cinefinder/movie/util/UtilParse.java
@@ -2,6 +2,7 @@ package com.cinefinder.movie.util;
 
 import com.cinefinder.movie.data.model.BoxOffice;
 import com.cinefinder.movie.data.model.MovieDetails;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -17,203 +18,185 @@ import java.util.Properties;
 
 @Slf4j
 public class UtilParse {
-    public static List<BoxOffice> extractDailyBoxOfficeInfoList(String response) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
+    public static List<BoxOffice> extractDailyBoxOfficeInfoList(String response) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
 
-            // 1. 일간 박스오피스 목록 파싱
-            JsonNode root = mapper.readTree(response);
-            JsonNode dailyBoxOfficeList = root.path("boxOfficeResult")
-                    .path("dailyBoxOfficeList");
+        // 1. 일간 박스오피스 목록 파싱
+        JsonNode root = mapper.readTree(response);
+        JsonNode dailyBoxOfficeList = root.path("boxOfficeResult")
+                .path("dailyBoxOfficeList");
 
-            // 2. 요청 및 응답 List 생성
-            List<BoxOffice> list = new ArrayList<>();
-            for (JsonNode node : dailyBoxOfficeList) {
-                String movieNm = node.path("movieNm").asText();
+        // 2. 요청 및 응답 List 생성
+        List<BoxOffice> list = new ArrayList<>();
+        for (JsonNode node : dailyBoxOfficeList) {
+            String movieNm = node.path("movieNm").asText();
 
-                BoxOffice boxOffice = BoxOffice.builder()
-                    .rank(node.path("rank").asText())
-                    .movieNm(movieNm)
-                    .movieKey(UtilString.normalizeMovieKey(movieNm))
-                    .build();
+            BoxOffice boxOffice = BoxOffice.builder()
+                .rank(node.path("rank").asText())
+                .movieNm(movieNm)
+                .movieKey(UtilString.normalizeMovieKey(movieNm))
+                .build();
 
-                list.add(boxOffice);
-            }
-
-            return list;
-        } catch (Exception e) {
-            // TODO: JSON 데이터 파싱 실패 시 예외 처리
-            throw new RuntimeException("일간 박스오피스 목록 추출 중 오류 발생", e);
+            list.add(boxOffice);
         }
+
+        return list;
     }
 
-    public static List<MovieDetails> extractMovieDetailsList(String response) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            List<MovieDetails> list = new ArrayList<>();
+    public static List<MovieDetails> extractMovieDetailsList(String response) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        List<MovieDetails> list = new ArrayList<>();
 
-            // 1. 일간 박스오피스 목록 파싱
-            JsonNode result = mapper.readTree(response)
-                .path("Data").get(0)
-                .path("Result");
+        // 1. 일간 박스오피스 목록 파싱
+        JsonNode result = mapper.readTree(response)
+            .path("Data").get(0)
+            .path("Result");
 
-            // 2. 응답 결과가 없다면
-            if (result.isMissingNode()) {
-                log.warn("❌ [영화 상세정보 추출] API 응답 결과가 없음");
-                return list;
-            }
-
-            // 3. 요청 및 응답 List 생성
-            for (JsonNode node : result) {
-                String plotText = "";
-                String runtime = "";
-                String ratingGrade = "";
-                String releaseDate = "";
-
-                List<String> directors = new ArrayList<>();
-                List<String> actors = new ArrayList<>();
-                List<String> vods = new ArrayList<>();
-
-                String title = node.path("title").asText();
-                String titleEng = node.path("titleEng").asText();
-                String nation = node.path("nation").asText();
-                String genre = node.path("genre").asText();
-                String posters = node.path("posters").asText();
-                String stlls = node.path("stlls").asText();
-
-                JsonNode plotTextNodes = node.path("plots").path("plot");
-
-                for (JsonNode plotTextNode : plotTextNodes) {
-                    String lang = plotTextNode.path("plotLang").asText();
-                    if ("한국어".equals(lang)) {
-                        plotText = plotTextNode.path("plotText").asText();
-                        break;
-                    }
-                }
-
-                JsonNode ratingNodes = node.path("ratings").path("rating");
-                for (JsonNode ratingNode : ratingNodes) {
-                    runtime = UtilString.normalizeJsonNodeText(ratingNode.path("runtime").asText());
-                    ratingGrade = UtilString.normalizeJsonNodeText(ratingNode.path("ratingGrade").asText());
-                    releaseDate = UtilString.normalizeJsonNodeText(ratingNode.path("releaseDate").asText())
-                            .replaceAll("-", "");
-                }
-
-                JsonNode directorsNodes = node.path("directors").path("director");
-                for (JsonNode directorNode : directorsNodes) directors.add(directorNode.path("directorNm").asText());
-
-                JsonNode actorsNodes = node.path("actors").path("actor");
-                for (JsonNode actorNode : actorsNodes) actors.add(actorNode.path("actorNm").asText());
-                if (actors.size() > 5) actors = actors.subList(0, 5);
-
-                JsonNode vodsNode = node.path("vods").path("vod");
-                for (JsonNode vod : vodsNode) vods.add(vod.path("vodUrl").asText());
-
-                MovieDetails movieDetails = MovieDetails.builder()
-                    .title(title)
-                    .titleEng(titleEng)
-                    .nation(nation)
-                    .genre(genre)
-                    .plotText(plotText)
-                    .runtime(runtime)
-                    .ratingGrade(ratingGrade)
-                    .releaseDate(releaseDate)
-                    .posters(posters)
-                    .stlls(stlls)
-                    .directors(String.join("|", directors))
-                    .actors(String.join("|", actors))
-                    .vods(String.join("|", vods))
-                    .build();
-
-                list.add(movieDetails);
-            }
-
+        // 2. 응답 결과가 없다면
+        if (result.isMissingNode()) {
+            log.warn("❌ [영화 상세정보 추출] API 응답 결과가 없음");
             return list;
-        } catch (Exception e) {
-            // TODO: JSON 데이터 파싱 실패 시 예외 처리
-            throw new RuntimeException("영화 상세정보 추출 중 오류 발생", e);
         }
+
+        // 3. 요청 및 응답 List 생성
+        for (JsonNode node : result) {
+            String plotText = "";
+            String runtime = "";
+            String ratingGrade = "";
+            String releaseDate = "";
+
+            List<String> directors = new ArrayList<>();
+            List<String> actors = new ArrayList<>();
+            List<String> vods = new ArrayList<>();
+
+            String title = node.path("title").asText();
+            String titleEng = node.path("titleEng").asText();
+            String nation = node.path("nation").asText();
+            String genre = node.path("genre").asText();
+            String posters = node.path("posters").asText();
+            String stlls = node.path("stlls").asText();
+
+            JsonNode plotTextNodes = node.path("plots").path("plot");
+
+            for (JsonNode plotTextNode : plotTextNodes) {
+                String lang = plotTextNode.path("plotLang").asText();
+                if ("한국어".equals(lang)) {
+                    plotText = plotTextNode.path("plotText").asText();
+                    break;
+                }
+            }
+
+            JsonNode ratingNodes = node.path("ratings").path("rating");
+            for (JsonNode ratingNode : ratingNodes) {
+                runtime = UtilString.normalizeJsonNodeText(ratingNode.path("runtime").asText());
+                ratingGrade = UtilString.normalizeJsonNodeText(ratingNode.path("ratingGrade").asText());
+                releaseDate = UtilString.normalizeJsonNodeText(ratingNode.path("releaseDate").asText())
+                        .replaceAll("-", "");
+            }
+
+            JsonNode directorsNodes = node.path("directors").path("director");
+            for (JsonNode directorNode : directorsNodes) directors.add(directorNode.path("directorNm").asText());
+
+            JsonNode actorsNodes = node.path("actors").path("actor");
+            for (JsonNode actorNode : actorsNodes) actors.add(actorNode.path("actorNm").asText());
+            if (actors.size() > 5) actors = actors.subList(0, 5);
+
+            JsonNode vodsNode = node.path("vods").path("vod");
+            for (JsonNode vod : vodsNode) vods.add(vod.path("vodUrl").asText());
+
+            MovieDetails movieDetails = MovieDetails.builder()
+                .title(title)
+                .titleEng(titleEng)
+                .nation(nation)
+                .genre(genre)
+                .plotText(plotText)
+                .runtime(runtime)
+                .ratingGrade(ratingGrade)
+                .releaseDate(releaseDate)
+                .posters(posters)
+                .stlls(stlls)
+                .directors(String.join("|", directors))
+                .actors(String.join("|", actors))
+                .vods(String.join("|", vods))
+                .build();
+
+            list.add(movieDetails);
+        }
+
+        return list;
     }
 
     public static List<MovieDetails> extractCgvMovieList(String response) {
-        try {
-            if (response == null) return new ArrayList<>();
+        if (response == null) return new ArrayList<>();
 
-            Document doc = Jsoup.parse(response);
-            Elements movieItems = doc.select("div.mm_list_item");
+        Document doc = Jsoup.parse(response);
+        Elements movieItems = doc.select("div.mm_list_item");
 
-            List<MovieDetails> movieDetailsList = new ArrayList<>();
-            for (Element movie : movieItems) {
-                MovieDetails movieDetails = new MovieDetails();
+        List<MovieDetails> movieDetailsList = new ArrayList<>();
+        for (Element movie : movieItems) {
+            MovieDetails movieDetails = new MovieDetails();
 
-                movieDetails.setTitle(movie.selectFirst("div.mm_list_item strong.tit").text());
+            movieDetails.setTitle(movie.selectFirst("div.mm_list_item strong.tit").text());
 
-                Element button = movie.selectFirst("a.btn_reserve");
-                String onclick = button.attr("onclick");
-                String[] argsArray = onclick.split("'");
-                if (argsArray.length >= 4) {
-                    movieDetails.setCgvCode(argsArray[3]);
-                }
-
-                movieDetailsList.add(movieDetails);
+            Element button = movie.selectFirst("a.btn_reserve");
+            String onclick = button.attr("onclick");
+            String[] argsArray = onclick.split("'");
+            if (argsArray.length >= 4) {
+                movieDetails.setCgvCode(argsArray[3]);
             }
 
-            return movieDetailsList;
-        } catch (Exception e) {
-            // TODO: JSON 데이터 파싱 실패 시 예외 처리
-            throw new RuntimeException("영화 제목 목록 추출 중 오류 발생", e);
+            movieDetailsList.add(movieDetails);
         }
+
+        return movieDetailsList;
     }
 
-    public static List<MovieDetails> extractMegaBoxMovieList(String response) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
+    public static List<MovieDetails> extractMegaBoxMovieList(String response) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
 
-            JsonNode curationBannerListNodes = mapper.readTree(response).path("movieList");
+        JsonNode curationBannerListNodes = mapper.readTree(response).path("movieList");
 
-            List<MovieDetails> movieDetailsList = new ArrayList<>();
-            for (JsonNode node : curationBannerListNodes) {
-                MovieDetails movieDetails = new MovieDetails();
+        List<MovieDetails> movieDetailsList = new ArrayList<>();
+        for (JsonNode node : curationBannerListNodes) {
+            MovieDetails movieDetails = new MovieDetails();
 
-                movieDetails.setTitle(decodeUnicode(node.path("movieNm").asText()));
-                movieDetails.setMegaBoxCode(node.path("movieNo").asText());
+            movieDetails.setTitle(decodeUnicode(node.path("movieNm").asText()));
+            movieDetails.setMegaBoxCode(node.path("movieNo").asText());
 
-                movieDetailsList.add(movieDetails);
-            }
-
-            return movieDetailsList;
-        } catch (Exception e) {
-            // TODO: JSON 데이터 파싱 실패 시 예외 처리
-            throw new RuntimeException("영화 제목 목록 추출 중 오류 발생", e);
+            movieDetailsList.add(movieDetails);
         }
+
+        return movieDetailsList;
     }
 
-    public static List<MovieDetails> extractLotteCinemaMovieList(String response) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
+    public static List<MovieDetails> extractLotteCinemaMovieList(String response) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
 
-            JsonNode items = mapper.readTree(response)
-                .path("Movies")
-                .path("Items");
+        JsonNode items = mapper.readTree(response)
+            .path("Movies")
+            .path("Items");
 
-            List<MovieDetails> movieDetailsList = new ArrayList<>();
-            for (JsonNode node : items) {
-                MovieDetails movieDetails = new MovieDetails();
+        List<MovieDetails> movieDetailsList = new ArrayList<>();
+        for (JsonNode node : items) {
+            MovieDetails movieDetails = new MovieDetails();
 
-                movieDetails.setTitle(decodeUnicode(node.path("MovieNameKR").asText()));
-                movieDetails.setLotteCinemaCode(node.path("RepresentationMovieCode").asText());
+            movieDetails.setTitle(decodeUnicode(node.path("MovieNameKR").asText()));
+            movieDetails.setLotteCinemaCode(node.path("RepresentationMovieCode").asText());
 
-                movieDetailsList.add(movieDetails);
-            }
-
-            return movieDetailsList;
-        } catch (Exception e) {
-            // TODO: JSON 데이터 파싱 실패 시 예외 처리
-            throw new RuntimeException("영화 제목 목록 추출 중 오류 발생", e);
+            movieDetailsList.add(movieDetails);
         }
+
+        return movieDetailsList;
     }
 
     private static String decodeUnicode(String input) throws IOException {
+        input = input.replaceAll("&amp;", "&")
+            .replaceAll("&lt;", "<")
+            .replaceAll("&gt;", ">")
+            .replaceAll("&quot;", "\"")
+            .replaceAll("&apos;", "'")
+            .replaceAll("&nbsp;", " ");
+
         Properties prop = new Properties();
         prop.load(new java.io.StringReader("key=" + input));
         return prop.getProperty("key");


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 영화 정보 수집 및 저장 로직 에러
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  1. CGV, 롯데시네마 현재상영중 영화만 수집하는 문제
      - 개봉예정작도 수집하도록 수정
      - CGV의 경우 단순 API 변경
      - 롯데시네마의 경우 현재상영중, 개봉예정작 API 2번 호출하도록 수정 
  3. DB에 영화 데이터 이미 존재할 경우 갱신 안 됨
      - `fetchMultiplexMovieDetails()` 메서드에 트랜잭션이 걸려있지 않아 `originMovie.updateMovie(movie);` 더티체킹 미수행
      - 중복된 영화명에 대한 데이터를 저장할 때 SQL 예외가 발생하는데, 영화 데이터(기존 영화 / 신규 영화)를 갱신하기 위해서는 롤백하면 안되므로 트랜잭션을 걸 수는 없음
      - 명시적으로 save() 처리
  4. 메가박스 제목 HTML 예약어 필터링
      - 메가박스만 "릴로 &amp; 스티치"와 같이 제목에 HTML 예약어가 포함된 경우가 있음(`&amp;`)
      - 이런 경우 KMDB API 응답을 제대로 받을 수 없으므로 해당 영화는 메가박스 영화코드를 못 받아옴
      - HTML 예약어 필터링 로직 추가
  5. 트랜잭션 설정
  6. 예외 처리
 ## 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - 충돌 해결 실패로 인한 재PR
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #38 
