### PR TITLE
fix: 영화 상세정보 조회 시 DB 값을 가져올 때 감독, 배우, VOD 목록에 잘못된 값 주입되는 부분 수정

### DIFF
--- a/src/main/java/com/cinefinder/favorite/data/Favorite.java
+++ b/src/main/java/com/cinefinder/favorite/data/Favorite.java
@@ -1,4 +1,4 @@
-package com.cinefinder.favorite;
+package com.cinefinder.favorite.data;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/cinefinder/favorite/data/repository/FavoriteRepository.java
+++ b/src/main/java/com/cinefinder/favorite/data/repository/FavoriteRepository.java
@@ -1,6 +1,6 @@
 package com.cinefinder.favorite.data.repository;
 
-import com.cinefinder.favorite.Favorite;
+import com.cinefinder.favorite.data.Favorite;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/cinefinder/favorite/mapper/FavoriteMapper.java
+++ b/src/main/java/com/cinefinder/favorite/mapper/FavoriteMapper.java
@@ -1,6 +1,6 @@
 package com.cinefinder.favorite.mapper;
 
-import com.cinefinder.favorite.Favorite;
+import com.cinefinder.favorite.data.Favorite;
 import com.cinefinder.favorite.data.dto.FavoriteRequestDto;
 import com.cinefinder.favorite.model.FavoriteMovie;
 import com.cinefinder.movie.data.Movie;

--- a/src/main/java/com/cinefinder/movie/mapper/MovieMapper.java
+++ b/src/main/java/com/cinefinder/movie/mapper/MovieMapper.java
@@ -20,9 +20,9 @@ public class MovieMapper {
             .ratingGrade(movie.getRatingGrade())
             .releaseDate(movie.getReleaseDate())
             .runtime(movie.getRuntime())
-            .directors(movie.getCgvCode())
-            .actors(movie.getCgvCode())
-            .vods(movie.getCgvCode())
+            .directors(movie.getDirectors())
+            .actors(movie.getActors())
+            .vods(movie.getVods())
             .build();
     }
 


### PR DESCRIPTION
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 영화 상세정보 조회 시 DB 값을 가져올 때 감독, 배우, VOD 목록에 잘못된 값 주입되는 부분 수정
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - MovieMapper.toMovieDetails() 수정
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #40 
