### PR TITLE
refactor: 박스오피스 데이터 저장 시 movieId도 함께 저장하도록 수정

### DIFF
--- a/src/main/java/com/cinefinder/movie/controller/MovieController.java
+++ b/src/main/java/com/cinefinder/movie/controller/MovieController.java
@@ -21,7 +21,7 @@ public class MovieController {
     private final MovieDetailService movieDetailService;
 
     @GetMapping("/box-office/daily")
-    public ResponseEntity<BaseResponse<List<BoxOffice>>> fetchDailyBoxOfficeInfo() {
+    public ResponseEntity<BaseResponse<List<BoxOffice>>> getDailyBoxOfficeInfo() {
         return ResponseMapper.successOf(ApiStatus._OK, boxOfficeService.getDailyBoxOfficeInfo(), MovieController.class);
     }
 

--- a/src/main/java/com/cinefinder/movie/data/Movie.java
+++ b/src/main/java/com/cinefinder/movie/data/Movie.java
@@ -15,7 +15,13 @@ import lombok.NoArgsConstructor;
 public class Movie {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
+
+    @Column(unique = true)
+    private String title;
+
+    @Column
+    private String movieKey;
 
     @Column
     private String cgvCode;
@@ -25,9 +31,6 @@ public class Movie {
 
     @Column
     private String lotteCinemaCode;
-
-    @Column(unique = true)
-    private String title;
 
     @Column
     private String titleEng;

--- a/src/main/java/com/cinefinder/movie/data/model/BoxOffice.java
+++ b/src/main/java/com/cinefinder/movie/data/model/BoxOffice.java
@@ -8,8 +8,16 @@ import lombok.*;
 @Builder
 @ToString
 public class BoxOffice {
-    @Setter
     private String rank;        /* 순위 */
+    private Long movieId;       /* 영화 ID */
     private String movieKey;    /* 정규화된 영화명 키 */
     private String movieNm;     /* 영화명 */
+
+    public void updateRank(String rank) {
+        this.rank = rank;
+    }
+
+    public void updateMovieId(Long movieId) {
+        this.movieId = movieId;
+    }
 }

--- a/src/main/java/com/cinefinder/movie/data/model/BoxOffice.java
+++ b/src/main/java/com/cinefinder/movie/data/model/BoxOffice.java
@@ -8,10 +8,11 @@ import lombok.*;
 @Builder
 @ToString
 public class BoxOffice {
-    private String rank;        /* 순위 */
-    private Long movieId;       /* 영화 ID */
-    private String movieKey;    /* 정규화된 영화명 키 */
-    private String movieNm;     /* 영화명 */
+    private String rank;               /* 순위 */
+    private Long movieId;              /* 영화 ID */
+    private String movieKey;           /* 정규화된 영화명 키 */
+    private String movieNm;            /* 영화명 */
+    private MovieDetails movieDetails; /* 영화상세정보 */
 
     public void updateRank(String rank) {
         this.rank = rank;
@@ -19,5 +20,9 @@ public class BoxOffice {
 
     public void updateMovieId(Long movieId) {
         this.movieId = movieId;
+    }
+
+    public void updateMovieDetails(MovieDetails movieDetails) {
+        this.movieDetails = movieDetails;
     }
 }

--- a/src/main/java/com/cinefinder/movie/data/model/MovieDetails.java
+++ b/src/main/java/com/cinefinder/movie/data/model/MovieDetails.java
@@ -3,21 +3,20 @@ package com.cinefinder.movie.data.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
-import java.util.List;
-
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MovieDetails {
-    private String cgvCode;
-    private String megaBoxCode;
-    private String lotteCinemaCode;
+    private Long movieId;              /* 영화 ID */
+    private String cgvCode;            /* CGV 영화 코드 */
+    private String megaBoxCode;        /* 메가박스 영화 코드 */
+    private String lotteCinemaCode;    /* 롯데시네마 영화 코드 */
     private String title;              /* 제목 */
     private String titleEng;           /* 영문 제목 */
+    private String movieKey;           /* 정규화된 제목 */
     private String nation;             /* 국가 */
     private String genre;              /* 장르 */
     private String posters;            /* 포스터 URL 목록 */
@@ -29,4 +28,30 @@ public class MovieDetails {
     private String directors;          /* 감독 */
     private String actors;             /* 배우 */
     private String vods;               /* VOD URL 목록 */
+
+    public void updateMovieId(Long movieId) {
+        this.movieId = movieId;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateCodes(MovieDetails movieDetails) {
+        updateCgvCode(movieDetails.getCgvCode());
+        updateMegaBoxCode(movieDetails.getMegaBoxCode());
+        updateLotteCinemaCode(movieDetails.getLotteCinemaCode());
+    }
+
+    public void updateCgvCode(String cgvCode) {
+        this.cgvCode = cgvCode;
+    }
+
+    public void updateMegaBoxCode(String megaBoxCode) {
+        this.megaBoxCode = megaBoxCode;
+    }
+
+    public void updateLotteCinemaCode(String lotteCinemaCode) {
+        this.lotteCinemaCode = lotteCinemaCode;
+    }
 }

--- a/src/main/java/com/cinefinder/movie/data/repository/MovieRepository.java
+++ b/src/main/java/com/cinefinder/movie/data/repository/MovieRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface MovieRepository extends JpaRepository<Movie, Long> {
-    Optional<Movie> findByMovieKey(String title);
+    Optional<Movie> findByMovieKey(String movieKey);
     Movie findByCgvCode(String cgvCode);
     Movie findByLotteCinemaCode(String lotteCode);
     Movie findByMegaBoxCode(String megaCode);
@@ -24,9 +24,9 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
     List<Movie> findByMovieIdList(@Param("movieIdList") List<Long> movieIdList);
 
     @Query(value = """
-        SELECT id
-        FROM movie
-        WHERE movie_key = :movieKey
-    """, nativeQuery = true)
+        SELECT m.id
+        FROM Movie m
+        WHERE m.movieKey = :movieKey
+    """)
     Long findMovieIdByMovieKey(@Param("movieKey") String movieKey);
 }

--- a/src/main/java/com/cinefinder/movie/data/repository/MovieRepository.java
+++ b/src/main/java/com/cinefinder/movie/data/repository/MovieRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface MovieRepository extends JpaRepository<Movie, Long> {
-    Optional<Movie> findByTitle(String title);
+    Optional<Movie> findByMovieKey(String title);
     Movie findByCgvCode(String cgvCode);
     Movie findByLotteCinemaCode(String lotteCode);
     Movie findByMegaBoxCode(String megaCode);
@@ -22,4 +22,11 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
         WHERE id IN :movieIdList
     """, nativeQuery = true)
     List<Movie> findByMovieIdList(@Param("movieIdList") List<Long> movieIdList);
+
+    @Query(value = """
+        SELECT id
+        FROM movie
+        WHERE movie_key = :movieKey
+    """, nativeQuery = true)
+    Long findMovieIdByMovieKey(@Param("movieKey") String movieKey);
 }

--- a/src/main/java/com/cinefinder/movie/mapper/MovieMapper.java
+++ b/src/main/java/com/cinefinder/movie/mapper/MovieMapper.java
@@ -7,11 +7,13 @@ import com.cinefinder.movie.data.model.MovieDetails;
 public class MovieMapper {
     public static MovieDetails toMovieDetails(Movie movie) {
         return MovieDetails.builder()
+            .movieId(movie.getId())
             .cgvCode(movie.getCgvCode())
             .megaBoxCode(movie.getMegaBoxCode())
             .lotteCinemaCode(movie.getLotteCinemaCode())
             .title(movie.getTitle())
             .titleEng(movie.getTitleEng())
+            .movieKey(movie.getMovieKey())
             .nation(movie.getNation())
             .genre(movie.getGenre())
             .posters(movie.getPosters())
@@ -28,6 +30,7 @@ public class MovieMapper {
 
     public static Movie toEntity(MovieDetails movieDetails, MovieDetails response) {
         return Movie.builder()
+            .movieKey(response.getMovieKey())
             .cgvCode(movieDetails.getCgvCode())
             .megaBoxCode(movieDetails.getMegaBoxCode())
             .lotteCinemaCode(movieDetails.getLotteCinemaCode())

--- a/src/main/java/com/cinefinder/movie/scheduler/MovieScheduler.java
+++ b/src/main/java/com/cinefinder/movie/scheduler/MovieScheduler.java
@@ -17,15 +17,15 @@ public class MovieScheduler {
     @Scheduled(cron = "0 0 11 * * *")
     public void fetchMovieInfoScheduler() throws Exception {
         try {
-            boxOfficeService.fetchDailyBoxOfficeInfo();
-        } catch (Exception e) {
-            log.error("‼️ 박스오피스 정보 패치 중 오류 발생", e);
-        }
-
-        try {
             movieDetailService.fetchMultiplexMovieDetails();
         } catch (Exception e) {
             log.error("‼️ 멀티플렉스 3사 영화 상세정보 패치 중 오류 발생", e);
+        }
+
+        try {
+            boxOfficeService.fetchDailyBoxOfficeInfo();
+        } catch (Exception e) {
+            log.error("‼️ 박스오피스 정보 패치 중 오류 발생", e);
         }
     }
 }

--- a/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
@@ -45,7 +45,7 @@ public class BoxOfficeService {
         String latestDateRedisKey = "dailyBoxOffice:" + latestDate;
 
         if (redisTemplate.hasKey(latestDateRedisKey)) {
-            log.info("박스오피스 캐시 조회 : {}", latestDateRedisKey);
+            log.debug("✅ 박스오피스 캐시 조회 : {}", latestDateRedisKey);
             return redisTemplate.opsForHash()
                 .entries(latestDateRedisKey)
                 .entrySet()
@@ -62,7 +62,7 @@ public class BoxOfficeService {
                 .sorted(Comparator.comparingInt(info -> Integer.parseInt(info.getRank())))
                 .collect(Collectors.toList());
         } else {
-            log.info("박스오피스 캐싱 : {}", latestDateRedisKey);
+            log.debug("✅ 박스오피스 캐싱 : {}", latestDateRedisKey);
             return fetchDailyBoxOfficeInfo();
         }
     }

--- a/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
@@ -8,6 +8,7 @@ import com.cinefinder.movie.util.UtilParse;
 import com.cinefinder.movie.util.UtilString;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BoxOfficeService {
@@ -41,7 +43,7 @@ public class BoxOfficeService {
         String latestDateRedisKey = "dailyBoxOffice:" + latestDate;
 
         if (redisTemplate.hasKey(latestDateRedisKey)) {
-
+            log.info("박스오피스 캐시 조회 : {}", latestDateRedisKey);
             return redisTemplate.opsForHash()
                 .entries(latestDateRedisKey)
                 .entrySet()
@@ -55,6 +57,7 @@ public class BoxOfficeService {
                 .sorted(Comparator.comparingInt(info -> Integer.parseInt(info.getRank())))
                 .collect(Collectors.toList());
         } else {
+            log.info("박스오피스 캐싱 : {}", latestDateRedisKey);
             return fetchDailyBoxOfficeInfo();
         }
     }

--- a/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/cinefinder/movie/service/BoxOfficeService.java
@@ -3,11 +3,11 @@ package com.cinefinder.movie.service;
 import com.cinefinder.global.exception.custom.CustomException;
 import com.cinefinder.global.util.statuscode.ApiStatus;
 import com.cinefinder.movie.data.model.BoxOffice;
-import com.cinefinder.movie.util.UtilString;
+import com.cinefinder.movie.data.repository.MovieRepository;
 import com.cinefinder.movie.util.UtilParse;
+import com.cinefinder.movie.util.UtilString;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -34,18 +33,14 @@ public class BoxOfficeService {
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final RedisTemplate<String, Object> redisTemplate;
+    private final MovieRepository movieRepository;
 
     public List<BoxOffice> getDailyBoxOfficeInfo() {
         ObjectMapper mapper = new ObjectMapper();
-
-        // 1. 최신일자 계산
         String latestDate = UtilString.getLatestDateString();
         String latestDateRedisKey = "dailyBoxOffice:" + latestDate;
-        log.info("🔑 [일간 박스오피스 정보 조회] REDIS 최신일자 키 이름 : {}", latestDateRedisKey);
 
-        // 2. 일간 박스오피스 정보 응답 분기 처리
         if (redisTemplate.hasKey(latestDateRedisKey)) {
-            log.info("✅ {} 키 존재 ... 캐시된 데이터 조회", latestDateRedisKey);
 
             return redisTemplate.opsForHash()
                 .entries(latestDateRedisKey)
@@ -54,49 +49,37 @@ public class BoxOfficeService {
                 .map(entry -> {
                     String rank = entry.getKey().toString();
                     BoxOffice boxOffice = mapper.convertValue(entry.getValue(), BoxOffice.class);
-                    boxOffice.setRank(rank);
+                    boxOffice.updateRank(rank);
                     return boxOffice;
                 })
                 .sorted(Comparator.comparingInt(info -> Integer.parseInt(info.getRank())))
                 .collect(Collectors.toList());
         } else {
-            log.info("✅ {} 키 없음 ... KOBIS API 호출 후 캐싱", latestDateRedisKey);
-
             return fetchDailyBoxOfficeInfo();
         }
     }
 
     public List<BoxOffice> fetchDailyBoxOfficeInfo() {
         try {
-            // 1. 최신일자 계산
             String latestDate = UtilString.getLatestDateString();
             String latestDateRedisKey = "dailyBoxOffice:" + latestDate;
-            log.info("🔑 [일간 박스오피스 정보 저장] REDIS 최신일자 키 이름 : {}", latestDateRedisKey);
-
-            // 2. 요청 URL 생성
             String url = String.format(
                 kobisRequestUrl + "?key=%s&targetDt=%s",
                 kobisServiceKey,
                 latestDate
             );
 
-            // 3. API 요청
             String response = restTemplate.getForObject(new URI(url), String.class);
 
-            // 4. 요청 및 응답 List 생성
-            List<BoxOffice> dailyBoxOfficeList = UtilParse.extractDailyBoxOfficeInfoList(response);
-
-            // 5. Redis 직전일자 데이터 삭제
             String beforeDate = UtilString.getBeforeDateString();
             String beforeDateRedisKey = "dailyBoxOffice:" + beforeDate;
             redisTemplate.delete(beforeDateRedisKey);
-            if (!redisTemplate.hasKey(beforeDateRedisKey)) log.info("⭕ 직전일자 데이터 삭제 완료");
 
-            // 6. Redis 데이터 저장
+            List<BoxOffice> dailyBoxOfficeList = UtilParse.extractDailyBoxOfficeInfoList(response);
             for (BoxOffice boxOffice : dailyBoxOfficeList) {
+                boxOffice.updateMovieId(movieRepository.findMovieIdByMovieKey(boxOffice.getMovieKey()));
                 redisTemplate.opsForHash().put(latestDateRedisKey, boxOffice.getRank(), boxOffice);
             }
-            log.info("⭕ REDIS 저장 완료");
 
             return dailyBoxOfficeList;
         } catch (URISyntaxException e) {

--- a/src/main/java/com/cinefinder/movie/service/MovieDetailService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieDetailService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MovieDetailService {
     @Value("${api.kmdb.request-url}")
@@ -51,42 +52,35 @@ public class MovieDetailService {
     private final MovieHelperService movieHelperService;
     private final MovieRepository movieRepository;
 
-    @Transactional(readOnly = true)
     public MovieDetails getMovieDetails(String title) {
-        ObjectMapper mapper = new ObjectMapper();
-        String movieKey = UtilString.normalizeMovieKey(title);
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            String movieKey = UtilString.normalizeMovieKey(title);
+            String redisKey = "movieDetails:" + movieKey;
 
-        String redisKey = "movieDetails:" + movieKey;
-        log.info("🔑 [영화 상세정보 캐시 조회] REDIS 키 이름 : {}", redisKey);
-
-        if (redisTemplate.hasKey(redisKey)) {
-            log.info("✅ {} 키 존재 ... 캐시된 데이터 조회", redisKey);
-            
-            Object object = redisTemplate.opsForHash().get(redisKey, movieKey);
-            return mapper.convertValue(object, MovieDetails.class);
-        } else {
-            log.info("✅ {} 키 없음 ... 영화 상세정보 데이터베이스 조회", redisKey);
-            
-            return getMovieDetailsFromDB(movieKey, title);
+            if (redisTemplate.hasKey(redisKey)) {
+                Object object = redisTemplate.opsForHash().get(redisKey, movieKey);
+                MovieDetails movieDetails = mapper.convertValue(object, MovieDetails.class);
+                movieDetails.updateMovieId(movieRepository.findMovieIdByMovieKey(movieKey));
+                return movieDetails;
+            } else {
+                return getMovieDetailsFromDB(movieKey, title);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ApiStatus._READ_FAIL, "영화 상세정보 캐시 조회 중 오류 발생");
         }
     }
 
-    @Transactional(readOnly = true)
     public MovieDetails getMovieDetailsFromDB(String movieKey, String title) {
         try {
-            log.info("🔑 [영화 상세정보 데이터베이스 조회] 영화키 이름 : {}", movieKey);
-
-            Optional<Movie> optionalMovie = movieRepository.findByTitle(movieKey);
+            Optional<Movie> optionalMovie = movieRepository.findByMovieKey(movieKey);
             if (optionalMovie.isPresent()) {
-                log.info("✅ 데이터 존재 ... 영화 상세정보 데이터베이스 조회");
                 return MovieMapper.toMovieDetails(optionalMovie.get());
             } else {
-                log.info("✅ 데이터 없음 ... KMDB API 호출 후 캐싱");
                 return fetchMovieDetails(movieKey, title);
             }
         } catch (Exception e) {
-            // TODO: 데이터베이스 조회 시 오류 예외 처리
-            throw new RuntimeException("영화 상세정보 데이터베이스 조회 중 오류 발생", e);
+            throw new CustomException(ApiStatus._READ_FAIL, "영화 상세정보 데이터베이스 조회 중 오류 발생");
         }
     }
 
@@ -94,33 +88,16 @@ public class MovieDetailService {
         try {
             String redisKey = "movieDetails:" + movieKey;
             MovieDetails returnMovieDetails = null;
-            log.info("🔑 [영화 상세정보 저장] REDIS 키 이름 : {}", redisKey);
-
-            // 1. 요청 URL 생성
             String url = String.format(
                 kmdbRequestUrl + "?collection=kmdb_new2&detail=Y&ServiceKey=%s&title=%s&sort=repRlsDate,1&listCount=1",
                 kmdbServiceKey,
                 URLEncoder.encode(title, StandardCharsets.UTF_8)
             );
 
-            // 2. API 요청
             String response = restTemplate.getForObject(new URI(url), String.class);
 
-            // 3. 저장 List 생성
-            List<MovieDetails> movieDetailsList = UtilParse.extractMovieDetailsList(response);
-
-            // 4. 응답 결과가 2개 이상이라면
-            if (movieDetailsList.size() >= 2) {
-                log.warn("❌ API 응답 결과가 2개 이상");
-
-                for (MovieDetails movieDetails : movieDetailsList) log.warn("{}", movieDetails.getTitle());
-                throw new IllegalArgumentException();
-            }
-
-            // 5. Redis 데이터 저장 및 만료일자 설정
+            List<MovieDetails> movieDetailsList = UtilParse.extractMovieDetailsList(response, movieKey);
             for (MovieDetails movieDetails : movieDetailsList) {
-                log.info("⭕ 영화 상세정보 데이터 캐싱 성공");
-
                 redisTemplate.opsForHash().put(redisKey, movieKey, movieDetails);
                 redisTemplate.expire(redisKey, 1, TimeUnit.DAYS);
                 returnMovieDetails = movieDetails;
@@ -138,64 +115,41 @@ public class MovieDetailService {
         }
     }
 
+    @Transactional
     public void fetchMultiplexMovieDetails() {
-        // 1. CGV API 요청
-        List<MovieDetails> totalMovieDetails = movieHelperService.requestMovieCgvApi();
+        try {
+            List<MovieDetails> totalMovieDetails = movieHelperService.requestMultiplexMovieApi();
 
-        // 2. MegaBox API 요청
-        totalMovieDetails.addAll(movieHelperService.requestMovieMegaBoxApi());
+            Map<String, MovieDetails> map = movieHelperService.mergeAndDeduplicateMovieDetails(totalMovieDetails);
+            for (Map.Entry<String, MovieDetails> entry : map.entrySet()) {
+                MovieDetails movieDetails = entry.getValue();
+                String movieKey = entry.getKey();
+                String redisKey = "movieDetails:" + movieKey;
+                String title = movieDetails.getTitle();
 
-        // 3. LotteCinema API 요청
-        totalMovieDetails.addAll(movieHelperService.requestMovieLotteCinemaApi());
+                MovieDetails response = getMovieDetails(title);
 
-        // 4. 3사 응답 결과 중복 제거하여 병합
-        Map<String, MovieDetails> map = movieHelperService.mergeAndDeduplicateMovieDetails(totalMovieDetails);
+                if (response == null) continue;
 
-        // 5. KMDB API 요청 및 저장
-        for (Map.Entry<String, MovieDetails> entry : map.entrySet()) {
-            MovieDetails movieDetails = entry.getValue();
-            String movieKey = entry.getKey();
-            String redisKey = "movieDetails:" + movieKey;
-            String title = movieDetails.getTitle();
+                MovieDetails originMovieDetails = (MovieDetails) redisTemplate.opsForHash().get(redisKey, movieKey);
+                if (originMovieDetails != null) {
+                    originMovieDetails.updateCodes(movieDetails);
+                    redisTemplate.opsForHash().put(redisKey, movieKey, originMovieDetails);
+                }
 
-            // API 요청
-            MovieDetails response = getMovieDetails(title);
-
-            // API 응답이 없을 경우 건너뛰기
-            if (response == null) continue;
-
-            // REDIS 각 멀티플렉스 영화코드 데이터 갱신
-            MovieDetails originMovieDetails = (MovieDetails) redisTemplate.opsForHash().get(redisKey, movieKey);
-            if (originMovieDetails != null) {
-                originMovieDetails.setCgvCode(movieDetails.getCgvCode());
-                originMovieDetails.setMegaBoxCode(movieDetails.getMegaBoxCode());
-                originMovieDetails.setLotteCinemaCode(movieDetails.getLotteCinemaCode());
-
-                redisTemplate.opsForHash().put(redisKey, movieKey, originMovieDetails);
-            }
-
-            // 엔티티로 변환 후 목록에 추가
-            Movie movie = MovieMapper.toEntity(movieDetails, response);
-            try {
-                movieRepository.save(movie);
-            } catch (Exception e) {
-                log.warn("‼️ {} 중복된 영화명 존재", movie.getTitle());
-
-                Optional<Movie> optionalOriginMovie = movieRepository.findByTitle(title);
+                Movie movie = MovieMapper.toEntity(movieDetails, response);
+                Optional<Movie> optionalOriginMovie = movieRepository.findByMovieKey(movieKey);
                 if (optionalOriginMovie.isPresent()) {
-                    Movie originMovie = optionalOriginMovie.get();
-                    originMovie.updateMovie(movie);
-                    movieRepository.save(originMovie);
-
-                    log.info("⭕ 중복 영화 정보 업데이트 완료 {}", movie.getTitle());
+                    movie.updateMovie(optionalOriginMovie.get());
                 } else {
-                    log.error("❌ 중복 예외 후 기존 영화 조회 실패 {}", movie.getTitle());
+                    movieRepository.save(movie);
                 }
             }
+        } catch (Exception e) {
+            throw new CustomException(ApiStatus._READ_FAIL, "멀티플렉스 영화 상세정보 저장 중 오류 발생");
         }
     }
 
-    @Transactional(readOnly = true)
     public Movie fetchMovieByBrandMovieCode(String brandName, String movieCode) {
         if (brandName.equals(cgvBrandName)) {
             return movieRepository.findByCgvCode(movieCode);
@@ -208,7 +162,6 @@ public class MovieDetailService {
         }
     }
 
-    @Transactional(readOnly = true)
     public List<Movie> getFavoriteMovieList(List<Long> movieIdList) {
         try {
             return movieRepository.findByMovieIdList(movieIdList);

--- a/src/main/java/com/cinefinder/movie/service/MovieDetailService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieDetailService.java
@@ -59,6 +59,7 @@ public class MovieDetailService {
             String redisKey = "movieDetails:" + movieKey;
 
             if (redisTemplate.hasKey(redisKey)) {
+                log.info("✅ 영화 상세정보 캐시 조회 : {}", movieKey);
                 Object object = redisTemplate.opsForHash().get(redisKey, movieKey);
                 MovieDetails movieDetails = mapper.convertValue(object, MovieDetails.class);
                 movieDetails.updateMovieId(movieRepository.findMovieIdByMovieKey(movieKey));
@@ -75,6 +76,7 @@ public class MovieDetailService {
         try {
             Optional<Movie> optionalMovie = movieRepository.findByMovieKey(movieKey);
             if (optionalMovie.isPresent()) {
+                log.info("✅ 영화 상세정보 DB 조회 {} : ", movieKey);
                 return MovieMapper.toMovieDetails(optionalMovie.get());
             } else {
                 return fetchMovieDetails(movieKey, title);
@@ -86,6 +88,7 @@ public class MovieDetailService {
 
     public MovieDetails fetchMovieDetails(String movieKey, String title) {
         try {
+            log.info("✅ 영화 상세정보 KMDB API 호출 {} : ", movieKey);
             String redisKey = "movieDetails:" + movieKey;
             MovieDetails returnMovieDetails = null;
             String url = String.format(

--- a/src/main/java/com/cinefinder/movie/service/MovieDetailService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieDetailService.java
@@ -59,7 +59,7 @@ public class MovieDetailService {
             String redisKey = "movieDetails:" + movieKey;
 
             if (redisTemplate.hasKey(redisKey)) {
-                log.info("✅ 영화 상세정보 캐시 조회 : {}", movieKey);
+                log.debug("✅ 영화 상세정보 캐시 조회 : {}", movieKey);
                 Object object = redisTemplate.opsForHash().get(redisKey, movieKey);
                 MovieDetails movieDetails = mapper.convertValue(object, MovieDetails.class);
                 movieDetails.updateMovieId(movieRepository.findMovieIdByMovieKey(movieKey));
@@ -76,7 +76,7 @@ public class MovieDetailService {
         try {
             Optional<Movie> optionalMovie = movieRepository.findByMovieKey(movieKey);
             if (optionalMovie.isPresent()) {
-                log.info("✅ 영화 상세정보 DB 조회 {} : ", movieKey);
+                log.debug("✅ 영화 상세정보 DB 조회 {} : ", movieKey);
                 return MovieMapper.toMovieDetails(optionalMovie.get());
             } else {
                 return fetchMovieDetails(movieKey, title);
@@ -88,7 +88,7 @@ public class MovieDetailService {
 
     public MovieDetails fetchMovieDetails(String movieKey, String title) {
         try {
-            log.info("✅ 영화 상세정보 KMDB API 호출 {} : ", movieKey);
+            log.debug("✅ 영화 상세정보 KMDB API 호출 {} : ", movieKey);
             String redisKey = "movieDetails:" + movieKey;
             MovieDetails returnMovieDetails = null;
             String url = String.format(

--- a/src/main/java/com/cinefinder/movie/service/MovieHelperService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieHelperService.java
@@ -36,8 +36,16 @@ public class MovieHelperService {
     private String lotteCinemaRequestUrl;
 
     private static final List<String> IGNORE_TITLE_LIST = List.of("AD");
-
     private final RestTemplate restTemplate = new RestTemplate();
+
+    public List<MovieDetails> requestMultiplexMovieApi() {
+        List<MovieDetails> multiplexMovieList = new ArrayList<>();
+        multiplexMovieList.addAll(requestMovieCgvApi());
+        multiplexMovieList.addAll(requestMovieMegaBoxApi());
+        multiplexMovieList.addAll(requestMovieLotteCinemaApi());
+
+        return multiplexMovieList;
+    }
 
     public List<MovieDetails> requestMovieCgvApi() {
         try {
@@ -138,15 +146,15 @@ public class MovieHelperService {
 
                 if (originMovieDetails != null) {
                     if (!StringUtil.isNullOrEmpty(cgvCode)) {
-                        originMovieDetails.setCgvCode(movieDetails.getCgvCode());
+                        originMovieDetails.updateCgvCode(movieDetails.getCgvCode());
                     }
 
                     if (!StringUtil.isNullOrEmpty(megaBoxCode)) {
-                        originMovieDetails.setMegaBoxCode(movieDetails.getMegaBoxCode());
+                        originMovieDetails.updateMegaBoxCode(movieDetails.getMegaBoxCode());
                     }
 
                     if (!StringUtil.isNullOrEmpty(lotteCinemaCode)) {
-                        originMovieDetails.setLotteCinemaCode(movieDetails.getLotteCinemaCode());
+                        originMovieDetails.updateLotteCinemaCode(movieDetails.getLotteCinemaCode());
                     }
 
                     if (originMovieDetails.getTitle().length() >= title.length()) {

--- a/src/main/java/com/cinefinder/movie/util/UtilParse.java
+++ b/src/main/java/com/cinefinder/movie/util/UtilParse.java
@@ -43,7 +43,7 @@ public class UtilParse {
         return list;
     }
 
-    public static List<MovieDetails> extractMovieDetailsList(String response) throws JsonProcessingException {
+    public static List<MovieDetails> extractMovieDetailsList(String response, String movieKey) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         List<MovieDetails> list = new ArrayList<>();
 
@@ -105,6 +105,7 @@ public class UtilParse {
             for (JsonNode vod : vodsNode) vods.add(vod.path("vodUrl").asText());
 
             MovieDetails movieDetails = MovieDetails.builder()
+                .movieKey(movieKey)
                 .title(title)
                 .titleEng(titleEng)
                 .nation(nation)
@@ -136,13 +137,13 @@ public class UtilParse {
         for (Element movie : movieItems) {
             MovieDetails movieDetails = new MovieDetails();
 
-            movieDetails.setTitle(movie.selectFirst("div.mm_list_item strong.tit").text());
+            movieDetails.updateTitle(movie.selectFirst("div.mm_list_item strong.tit").text());
 
             Element button = movie.selectFirst("a.btn_reserve");
             String onclick = button.attr("onclick");
             String[] argsArray = onclick.split("'");
             if (argsArray.length >= 4) {
-                movieDetails.setCgvCode(argsArray[3]);
+                movieDetails.updateCgvCode(argsArray[3]);
             }
 
             movieDetailsList.add(movieDetails);
@@ -160,8 +161,8 @@ public class UtilParse {
         for (JsonNode node : curationBannerListNodes) {
             MovieDetails movieDetails = new MovieDetails();
 
-            movieDetails.setTitle(decodeUnicode(node.path("movieNm").asText()));
-            movieDetails.setMegaBoxCode(node.path("movieNo").asText());
+            movieDetails.updateTitle(decodeUnicode(node.path("movieNm").asText()));
+            movieDetails.updateMegaBoxCode(node.path("movieNo").asText());
 
             movieDetailsList.add(movieDetails);
         }
@@ -180,8 +181,8 @@ public class UtilParse {
         for (JsonNode node : items) {
             MovieDetails movieDetails = new MovieDetails();
 
-            movieDetails.setTitle(decodeUnicode(node.path("MovieNameKR").asText()));
-            movieDetails.setLotteCinemaCode(node.path("RepresentationMovieCode").asText());
+            movieDetails.updateTitle(decodeUnicode(node.path("MovieNameKR").asText()));
+            movieDetails.updateLotteCinemaCode(node.path("RepresentationMovieCode").asText());
 
             movieDetailsList.add(movieDetails);
         }

--- a/src/main/java/com/cinefinder/movie/util/UtilString.java
+++ b/src/main/java/com/cinefinder/movie/util/UtilString.java
@@ -2,8 +2,15 @@ package com.cinefinder.movie.util;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class UtilString {
+    private static final List<String> NORMALIZE_STRING_LIST = List.of(
+        "[^\\p{IsHangul}\\p{IsAlphabetic}\\p{IsDigit}\\s]",
+        "\\s+",
+        "극장판"
+    );
+
     public static String getLatestDateString() {
         return getFormattedDateString(1);
     }
@@ -20,10 +27,11 @@ public class UtilString {
     }
 
     public static String normalizeMovieKey(String input) {
-        return input.toLowerCase()
-            .replaceAll("[^\\p{IsHangul}\\p{IsAlphabetic}\\p{IsDigit}\\s]", "")
-            .replaceAll("\\s+", "")
-            .trim();
+        for (String normalizeString : NORMALIZE_STRING_LIST) {
+            input = input.replaceAll(normalizeString, "");
+        }
+
+        return input.toLowerCase().trim();
     }
 
     public static String normalizeJsonNodeText(String input) {


### PR DESCRIPTION
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 박스오피스 데이터 저장 시 movieId도 함께 저장하도록 수정
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 박스오피스 데이터 movieId 캐싱하도록 수정
  - 박스오피스 데이터 조회 시 상세정보도 포함하도록 수정
  - 영화 상세정보 데이터베이스 저장 시 각 행별로 조회하여 저장/갱신 분기 처리
  - 좋아요, 채팅 등 박스오피스 Redis 데이터와 영화 MySQL 데이터 매핑을 위해 테이블에 movieKey 컬럼 추가
  - 영화 제목 정규화 시 "극장판" 문자열 필터링 추가
  - 로그 제거
  - 코드 간결화 등 리팩토링
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #46 
