### PR TITLE
fix: DB조회로 나오지 않는 영화의 영화 스케쥴 조회 시 warn으로 로그를 출력하고 넘어가도록 수정

### DIFF
--- a/src/main/java/com/cinefinder/screen/service/CgvScreenScheduleServiceImpl.java
+++ b/src/main/java/com/cinefinder/screen/service/CgvScreenScheduleServiceImpl.java
@@ -131,15 +131,14 @@ public class CgvScreenScheduleServiceImpl implements ScreenScheduleService {
 
         List<CinemaScheduleApiResponseDto> result = new ArrayList<>();
         for (JsonNode item : scheduleList) {
-            String startTime = item.path("PlayStartTm").asText();
-            String endTime = item.path("PlayEndTm").asText();
-
             String movieCode = item.path("MovieGroupCd").asText();
             var movie = movieDetailService.fetchMovieByBrandMovieCode(brandName, movieCode);
             if (movie == null) {
-                log.warn("CGV에서 찾을 수 없는 영화 정보가 있습니다. MovieCode: {}, MovieName: {}", movieCode, item.path("MovieNmKor").asText());
+                log.warn("{}에서 찾을 수 없는 영화 정보가 있습니다. MovieCode: {}, MovieName: {}", brandName, movieCode, item.path("MovieNmKor").asText());
                 continue;
             }
+            String startTime = item.path("PlayStartTm").asText();
+            String endTime = item.path("PlayEndTm").asText();
 
             CinemaScheduleApiResponseDto dto = new CinemaScheduleApiResponseDto(
                     brandService.getBrandInfo(brandName),

--- a/src/main/java/com/cinefinder/screen/service/LotteScreenScheduleServiceImpl.java
+++ b/src/main/java/com/cinefinder/screen/service/LotteScreenScheduleServiceImpl.java
@@ -2,6 +2,7 @@ package com.cinefinder.screen.service;
 
 import com.cinefinder.global.exception.custom.CustomException;
 import com.cinefinder.global.util.statuscode.ApiStatus;
+import com.cinefinder.movie.data.Movie;
 import com.cinefinder.movie.mapper.MovieMapper;
 import com.cinefinder.movie.service.MovieDetailService;
 import com.cinefinder.screen.data.dto.CinemaScheduleApiResponseDto;
@@ -104,6 +105,13 @@ public class LotteScreenScheduleServiceImpl implements ScreenScheduleService {
         if (!items.isArray()) return result;
 
         for (JsonNode item : items) {
+            String movieCode = item.path("RepresentationMovieCode").asText();
+            Movie movie = movieDetailService.fetchMovieByBrandMovieCode(brandName, movieCode);
+            if (movie == null) {
+                log.warn("{}에서 찾을 수 없는 영화 정보가 있습니다. MovieCode: {}, MovieName: {}", brandName, movieCode, item.path("MovieNameKR").asText());
+                continue;
+            }
+
             String start = item.path("StartTime").asText();  // "12:00"
             String end = item.path("EndTime").asText();      // "13:13"
             long runtimeMinutes = 0;

--- a/src/main/java/com/cinefinder/screen/service/MegaScreenScheduleServiceImpl.java
+++ b/src/main/java/com/cinefinder/screen/service/MegaScreenScheduleServiceImpl.java
@@ -2,6 +2,7 @@ package com.cinefinder.screen.service;
 
 import com.cinefinder.global.exception.custom.CustomException;
 import com.cinefinder.global.util.statuscode.ApiStatus;
+import com.cinefinder.movie.data.Movie;
 import com.cinefinder.movie.mapper.MovieMapper;
 import com.cinefinder.movie.service.MovieDetailService;
 import com.cinefinder.screen.data.dto.CinemaScheduleApiResponseDto;
@@ -83,6 +84,13 @@ public class MegaScreenScheduleServiceImpl implements ScreenScheduleService{
         JsonNode scheduleList = root.get("scheduleList");
         List<CinemaScheduleApiResponseDto> result = new ArrayList<>();
         for (JsonNode item : scheduleList) {
+            String movieCode = item.path("rpstMovieNo").asText();
+            Movie movie = movieDetailService.fetchMovieByBrandMovieCode(brandName, movieCode);
+            if (movie == null) {
+                log.warn("{}에서 찾을 수 없는 영화 정보가 있습니다. MovieCode: {}, MovieName: {}", brandName, movieCode, item.path("MovieNm").asText());
+                continue;
+            }
+
             CinemaScheduleApiResponseDto dto = new CinemaScheduleApiResponseDto(
                     brandService.getBrandInfo(brandName),
                     TheaterMapper.toSimplifiedTheaterDto(theaterService.getTheaterInfo(brandName, item.path("brchNo").asText())),


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - DB조회로 나오지 않는 영화의 영화 스케쥴 조회 시 warn으로 로그를 출력하고 넘어가도록 수정
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 각 3사의 영화 상영 정보를 가져올 때, DB로부터 영화 상세정보가 조회되지 않으면 넘어가도록 수정
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #51 
