### PR TITLE
fix: 다음 API 요청 시 포스터, 스틸컷 못 가져오는 문제 수정

### DIFF
--- a/src/main/java/com/cinefinder/favorite/service/FavoriteService.java
+++ b/src/main/java/com/cinefinder/favorite/service/FavoriteService.java
@@ -32,17 +32,14 @@ public class FavoriteService {
                     favoriteRequestDto.getUserId(),
                     favoriteRequestDto.getMovieId()
             );
-            log.info("✅ 좋아요 여부 {}", isExistFavorite);
 
             if (isExistFavorite) {
                 favoriteRepository.deleteByUserIdAndMovieId(
                         favoriteRequestDto.getUserId(),
                         favoriteRequestDto.getMovieId()
                 );
-                log.info("👎 좋아요 존재 ... 좋아요 취소");
             } else {
                 favoriteRepository.save(FavoriteMapper.toEntity(favoriteRequestDto));
-                log.info("👍 좋아요 없음 ... 좋아요 등록");
             }
         } catch (Exception e) {
             throw new CustomException(ApiStatus._OPERATION_FAIL, "좋아요 데이터 갱신 중 오류 발생");
@@ -69,7 +66,6 @@ public class FavoriteService {
     public List<FavoriteMovie> getFavoriteMovieListByUser(Long userId) {
         try {
             List<Long> movieIdList = favoriteRepository.findMovieIdListByUserId(userId);
-            log.info("✅ ID {} 사용자의 좋아요 등록 영화 개수 : {}", userId, movieIdList.size());
 
             if (movieIdList.isEmpty()) {
                 log.info("‼️ 영화 ID 목록 없음");
@@ -77,7 +73,6 @@ public class FavoriteService {
             }
 
             List<Movie> movieList = movieService.getFavoriteMovieList(movieIdList);
-            log.info("✅ ID 기반으로 조회한 영화정보 목록 개수 : {}", movieIdList.size());
 
             if (movieIdList.size() != movieList.size()) {
                 throw new RuntimeException("ID에 해당하는 영화정보를 모두 찾을 수 없음");

--- a/src/main/java/com/cinefinder/movie/data/model/MovieDetails.java
+++ b/src/main/java/com/cinefinder/movie/data/model/MovieDetails.java
@@ -33,7 +33,7 @@ public class MovieDetails {
     private String vods;               /* VOD URL 목록 */
 
     public boolean hasMissingRequiredField() {
-        return Stream.of(nation, plotText, runtime, genre, releaseDate, ratingGrade)
+        return Stream.of(nation, plotText, runtime, genre, releaseDate, ratingGrade, posters, stlls, vods)
             .anyMatch(StringUtil::isNullOrEmpty);
     }
 
@@ -44,6 +44,9 @@ public class MovieDetails {
         if (StringUtil.isNullOrEmpty(genre)) this.updateGenre(movieDetails.getGenre());
         if (StringUtil.isNullOrEmpty(releaseDate)) this.updateReleaseDate(movieDetails.getReleaseDate());
         if (StringUtil.isNullOrEmpty(ratingGrade)) this.updateRatingGrade(movieDetails.getRatingGrade());
+        if (StringUtil.isNullOrEmpty(posters)) this.updatePosters(movieDetails.getPosters());
+        if (StringUtil.isNullOrEmpty(stlls)) this.updateStlls(movieDetails.getStlls());
+        if (StringUtil.isNullOrEmpty(vods)) this.updateVods(movieDetails.getVods());
     }
 
     public void updateCodes(MovieDetails movieDetails) {

--- a/src/main/java/com/cinefinder/movie/service/MovieDbSyncService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieDbSyncService.java
@@ -50,11 +50,6 @@ public class MovieDbSyncService {
 
                 if (response == null) continue;
 
-                if (response.hasMissingRequiredField()) {
-                    MovieDetails daumMovieDetails = movieHelperService.requestMovieDaumApi(title);
-                    if (daumMovieDetails != null) { response.setMissingRequiredField(daumMovieDetails); }
-                }
-
                 MovieDetails originMovieDetails = (MovieDetails) redisTemplate.opsForHash().get(redisKey, movieKey);
                 if (originMovieDetails != null) {
                     originMovieDetails.updateCodes(movieDetails);

--- a/src/main/java/com/cinefinder/movie/util/UtilParse.java
+++ b/src/main/java/com/cinefinder/movie/util/UtilParse.java
@@ -151,9 +151,9 @@ public class UtilParse {
         }
 
         if (StringUtil.isNullOrEmpty(movieDetails.getPosters())) {
-            Element cContainer = doc.selectFirst("c-container[data-dc=EM1]");
-            if (cContainer != null) {
-                Element cThumb = cContainer.selectFirst("c-thumb");
+            Element cDocContent = doc.selectFirst("c-doc-content");
+            if (cDocContent != null) {
+                Element cThumb = cDocContent.selectFirst("c-thumb");
                 if (cThumb != null) movieDetails.updatePosters(cThumb.attr("data-original-src"));
             }
         }
@@ -169,7 +169,7 @@ public class UtilParse {
                 String tabText = tabElement.text();
                 switch (tabText) {
                     case "영상" -> vodList.add(tab.select("c-thumb").attr("data-href"));
-                    case "포토" -> stllList.add(tab.select("c-thumb").attr("data-origin-src"));
+                    case "포토" -> stllList.add(tab.select("c-thumb").attr("data-original-src"));
                 }
             }
 


### PR DESCRIPTION
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 다음 API 요청 시 포스터, 스틸컷 못 가져오는 문제 수정
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - resolveMovieDetails() 메서드에서 조회한 포스터, 스틸컷 모델에 미반영하여 반환
  - 좋아요 불필요 로그 삭제
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #76 