### PR TITLE
fix: 영화 상영 정보 조회 api에서 요청값을 영화 이름에서 영화 id를 받기로 수정

### DIFF
--- a/src/main/java/com/cinefinder/movie/controller/MovieController.java
+++ b/src/main/java/com/cinefinder/movie/controller/MovieController.java
@@ -36,7 +36,7 @@ public class MovieController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<BaseResponse<List<String>>> search(@RequestParam String keyword) {
+    public ResponseEntity<BaseResponse<List<Long>>> search(@RequestParam String keyword) {
         return ResponseMapper.successOf(ApiStatus._OK, movieService.searchMovies(keyword), MovieController.class);
     }
 }

--- a/src/main/java/com/cinefinder/movie/service/MovieService.java
+++ b/src/main/java/com/cinefinder/movie/service/MovieService.java
@@ -115,10 +115,10 @@ public class MovieService {
         }
     }
 
-    public List<String> searchMovies(String keyword) {
+    public List<Long> searchMovies(String keyword) {
         List<Movie> movies = movieRepository.searchMoviesByKeyword(keyword);
         return movies.stream()
-                .map(Movie::getTitle)
+                .map(Movie::getId)
                 .toList();
     }
 }

--- a/src/main/java/com/cinefinder/screen/data/dto/ScreenScheduleRequestDto.java
+++ b/src/main/java/com/cinefinder/screen/data/dto/ScreenScheduleRequestDto.java
@@ -12,5 +12,5 @@ public class ScreenScheduleRequestDto {
     private Double lat;
     private Double lng;
     private Double distance;
-    private List<String> movieNames;
+    private List<Long> movieIds;
 }

--- a/src/main/java/com/cinefinder/screen/service/ScreenScheduleAggregatorService.java
+++ b/src/main/java/com/cinefinder/screen/service/ScreenScheduleAggregatorService.java
@@ -44,12 +44,12 @@ public class ScreenScheduleAggregatorService {
         double lat = requestDto.getLat();
         double lng = requestDto.getLng();
         double distance = requestDto.getDistance();
-        List<String> movieNames = requestDto.getMovieNames();
+        List<Long> movieIds = requestDto.getMovieIds();
 
-        Map<String, List<String>> movieIds = getMovieIds(movieNames);
+        Map<String, List<String>> movieIdsByMultiplex = getMovieIdsByMultiplex(movieIds);
         Map<String, List<String>> theaterIds = theaterService.getNearbyTheaterCodes(lat, lng, distance);
 
-        List<CinemaScheduleApiResponseDto> schedules = getCinemaScheduleApiResponseDtos(screenScheduleServices, date, minTimeStr, maxTimeStr, theaterIds, movieIds);
+        List<CinemaScheduleApiResponseDto> schedules = getCinemaScheduleApiResponseDtos(screenScheduleServices, date, minTimeStr, maxTimeStr, theaterIds, movieIdsByMultiplex);
         List<MovieGroupedScheduleResponseDto> groupedSchedules = ScreenMapper.toGroupedSchedule(schedules);
         groupedSchedules.sort((a, b) -> {
             int scheduleCountA = a.getSchedule().values().stream()
@@ -98,30 +98,30 @@ public class ScreenScheduleAggregatorService {
         return schedules;
     }
 
-    private Map<String, List<String>> getMovieIds(List<String> movieNames) {
-        Map<String, List<String>> movieIds = new HashMap<>() {{
+    private Map<String, List<String>> getMovieIdsByMultiplex(List<Long> movieIds) {
+        Map<String, List<String>> movieIdsByMultiplex = new HashMap<>() {{
             put(cgvBrandName, new ArrayList<>());
             put(lotteBrandName, new ArrayList<>());
             put(megaBrandName, new ArrayList<>());
         }};
 
-        for (String movieName : movieNames) {
-            MovieDetails movieDetail = movieService.fetchMovieDetails(movieName);
+        for (Long movieId : movieIds) {
+            MovieDetails movieDetail = movieService.getMovieDetailsByMovieId(movieId);
             String cgvCode = movieDetail.getCgvCode();
             String lotteCode = movieDetail.getLotteCinemaCode();
             String megaCode = movieDetail.getMegaBoxCode();
 
             if (cgvCode != null) {
-                movieIds.get(cgvBrandName).add(cgvCode);
+                movieIdsByMultiplex.get(cgvBrandName).add(cgvCode);
             }
             if (lotteCode != null) {
-                movieIds.get(lotteBrandName).add(lotteCode);
+                movieIdsByMultiplex.get(lotteBrandName).add(lotteCode);
             }
             if (megaCode != null) {
-                movieIds.get(megaBrandName).add(megaCode);
+                movieIdsByMultiplex.get(megaBrandName).add(megaCode);
             }
         }
 
-        return movieIds;
+        return movieIdsByMultiplex;
     }
 }

--- a/src/main/java/com/cinefinder/screen/service/ScreenScheduleAggregatorService.java
+++ b/src/main/java/com/cinefinder/screen/service/ScreenScheduleAggregatorService.java
@@ -113,12 +113,18 @@ public class ScreenScheduleAggregatorService {
 
             if (cgvCode != null) {
                 movieIdsByMultiplex.get(cgvBrandName).add(cgvCode);
+            } else {
+                movieIdsByMultiplex.get(cgvBrandName).add("NONE");
             }
             if (lotteCode != null) {
                 movieIdsByMultiplex.get(lotteBrandName).add(lotteCode);
+            } else {
+                movieIdsByMultiplex.get(lotteBrandName).add("NONE");
             }
             if (megaCode != null) {
                 movieIdsByMultiplex.get(megaBrandName).add(megaCode);
+            } else {
+                movieIdsByMultiplex.get(megaBrandName).add("NONE");
             }
         }
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 영화 스케쥴 조회 요청 파라미터에서 DB상 영화 ID 기준으로 검색할 영화를 받아오도록 수정
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 영화 ID 기준으로 검색하도록 수정
  - DB에서 영화사 기준 영화 코드가 없을 시 모든 영화의 상영 정보를 가져오는 오류 수정
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - #88 
