### PR TITLE
fix: 채팅이 없는 영화는 채팅에 대한 추천 점수 계산하지 않도록 수정

### DIFF
--- a/src/main/java/com/cinefinder/recommend/service/RecommendService.java
+++ b/src/main/java/com/cinefinder/recommend/service/RecommendService.java
@@ -83,12 +83,17 @@ public class RecommendService {
                 double total = 0;
                 Long movieId = entry.getKey();
 
-                total += 3 * favoriteService.countFavoriteMovieList(movieId);
-                total += 2 * (entry.getValue() - 2);
-                total += (rankMap.get(movieId) != null) ? 2 - (0.1 * (rankMap.get(movieId) - 1)) : 0;
+                long favoriteCount = favoriteService.countFavoriteMovieList(movieId);
+                total += calculateFavoriteScore(favoriteCount);
+
+                Double sentiment = entry.getValue();
+                total += calculateSentimentScore(sentiment);
+
+                Integer rank = rankMap.get(movieId);
+                total += calculateRankScore(rank);
 
                 MovieResponseDto movieResponseDto = movieService.getMovieDetailsByMovieId(movieId);
-                movieResponseDto.updateFavoriteCount(favoriteService.countFavoriteMovieList(movieId));
+                movieResponseDto.updateFavoriteCount(favoriteCount);
 
                 RecommendResponseDto recommendResponseDto = RecommendResponseDto.builder()
                     .movieId(movieId)
@@ -126,5 +131,17 @@ public class RecommendService {
                 lock.unlock();
             }
         }
+    }
+
+    private double calculateFavoriteScore(long favoriteCount) {
+        return 3 * favoriteCount;
+    }
+
+    private double calculateSentimentScore(Double sentiment) {
+        return (sentiment != 0) ? 2 * (sentiment - 2) : 0;
+    }
+
+    private double calculateRankScore(Integer rank) {
+        return (rank != null) ? 2 - (0.1 * (rank - 1)) : 0;
     }
 }


### PR DESCRIPTION
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 채팅 없는 영화의 추천 점수가 음수 값으로 산정되는 문제
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 채팅이 없는 영화는 채팅에 대한 추천 점수 계산하지 않도록 수정
 ## Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #3333") -->
 - close #105 
